### PR TITLE
add `countDocuments()` to MockCollection

### DIFF
--- a/src/MockCollection.php
+++ b/src/MockCollection.php
@@ -337,6 +337,11 @@ class MockCollection extends Collection
         return $count;
     }
 
+    public function countDocuments($filter = [], array $options = [])
+    {
+        return $this->count($filter, $options);
+    }
+
     public function createIndex($key, array $options = [])
     {
         $name = '';


### PR DESCRIPTION
Fixes martin-helmich/php-mongomock#21